### PR TITLE
Add a message_id debug line so we know what email killed LS

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -92,6 +92,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   end # def run
 
   def parse_mail(mail)
+    # Add a debug message so we can track what message might cause an error later
+    @logger.debug("Working with message_id", :message_id => mail.message_id)
     # TODO(sissel): What should a multipart message look like as an event?
     # For now, just take the plain-text part and set it as the message.
     if mail.parts.count == 0


### PR DESCRIPTION
This adds the ability to return the message ID should there be an issue and the user wants to see what message ID was being processed. 
