### PR TITLE
Do not transcode_to_utf8 headers that are nil (was causing Error: undefi...

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -154,6 +154,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   # the mail gem will set the correct encoding on header strings decoding
   # and we want to transcode it to utf8
   def transcode_to_utf8(s)
-    s.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
+    unless s.nil?
+      s.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
+    end
   end
 end # class LogStash::Inputs::IMAP


### PR DESCRIPTION
I use the imap input plugin. My emails have a nil header value that was causing exceptions in the latest version of imap.rb and logstash. This is a pull request to prevent said exception by only calling encode in  transcode_to_utf8() for non-nil values.