### PR TITLE
Make usage of stop new semantics of LS

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -63,6 +63,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   end
 
   def run(queue)
+    @run_thread = Thread.current
     Stud.interval(@check_interval) do
       check_mail(queue)
     end
@@ -143,10 +144,10 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   end # def handle
 
   public
-  def teardown
+  def stop
+    Stud.stop!(@run_thread)
     $stdin.close
-    finished
-  end # def teardown
+  end
 
   private
 

--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'mail'
-  s.add_runtime_dependency 'stud'
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -1,8 +1,37 @@
 # encoding: utf-8
-#
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/imap"
 require "mail"
+require "net/imap"
+
+
+describe LogStash::Inputs::IMAP do
+
+  context "when interrupting the plugin" do
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) do
+        { "type" => "imap",
+          "host" => "localhost",
+          "user" => "logstash",
+          "password" => "secret" }
+      end
+      let(:imap) { double("imap") }
+      let(:ids)  { double("ids") }
+      before(:each) do
+        allow(imap).to receive(:login)
+        allow(imap).to receive(:select)
+        allow(imap).to receive(:close)
+        allow(imap).to receive(:disconnect)
+        allow(imap).to receive(:store)
+        allow(ids).to receive(:each_slice).and_return([])
+
+        allow(imap).to receive(:search).with("NOT SEEN").and_return(ids)
+        allow(Net::IMAP).to receive(:new).and_return(imap)
+      end
+    end
+  end
+
+end
 
 describe LogStash::Inputs::IMAP do
   user = "logstash"


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #9 
