### PR TITLE
Pin gem `mail` to 2.6.3 which is the last compatible version

### DIFF
--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mail'
+  s.add_runtime_dependency "mail", "2.6.3"
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Mail version higher than 2.6.3 cannot be installed inside logstash
because it validate the ruby version to be higher than 2.0.

```
Installing mime-types-data 3.2016.0221
Gem::InstallError: mime-types-data requires Ruby version >= 2.0.
```

The email output already pin the gem to this [version](https://github.com/logstash-plugins/logstash-output-email/blob/master/logstash-output-email.gemspec#L25)

Fix the failling jobs on travis https://travis-ci.org/logstash-plugins/logstash-input-imap