### PR TITLE
Attempt to fix build

### DIFF
--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mail'
+  s.add_runtime_dependency 'mail', '~> 2.6.3'
+  s.add_runtime_dependency 'mime-types', '2.6.2'
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
This properly pins the 'mime-types' not 'mail' gem for compat with jruby.