### PR TITLE
Fix missing text/plain crashes

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -116,7 +116,12 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
     else
       # Multipart message; use the first text/plain part we find
       part = mail.parts.find { |p| p.content_type.match @content_type_re } || mail.parts.first
-      message = part.decoded
+      # Some messages are missing parts such as text/plain. Fall back
+      begin
+           message = part.decoded
+      rescue NoMethodError
+           message = mail.body.decoded
+      end
     end
 
     @codec.decode(message) do |event|


### PR DESCRIPTION
Noticed in logstash 5.3.

Some of our applications do not properly add text/plain entries to their multi-part messages. This repeatedly crashes the input plugin.

This change let's the plugin fallback if the target part cannot be decoded. That seems to address the crashes. Whether this change is Correct way to handle it I'm less certain.

Log excerpt:
```
12:45:01.910 [[main]<imap] DEBUG logstash.inputs.imap - Working with message_id {:message_id=>"da93f5d6-9e42-11e8-898f-8f312f094cc3@server.example.com"}
12:45:01.919 [[main]<imap] ERROR logstash.pipeline - A plugin had an unrecoverable error. Will restart this plugin.
  Plugin: <LogStash::Inputs::IMAP id=>"system_mail_input", host=>"internal-relay.example.com", user=>"catchall", password=><password>, delete=>false, expunge=>false, type=>"system-mail", fetch_count=>3, verify_cert=>false, enable_metric=>true, codec=><LogStash::Codecs::Plain id=>"plain_2dd9d3d9-8e6e-4f2c-9fdc-0387100b3101", enable_metric=>true, charset=>"UTF-8">, secure=>true, folder=>"INBOX", lowercase_headers=>true, check_interval=>300, strip_attachments=>false, content_type=>"text/plain">
  Error: Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.
  Exception: NoMethodError
  Stack: /usr/share/logstash/vendor/bundle/jruby/1.9/gems/mail-2.6.4/lib/mail/message.rb:1903:in `decoded'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:119:in `parse_mail'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:88:in `check_mail'
org/jruby/RubyArray.java:1613:in `each'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:82:in `check_mail'
org/jruby/RubyArray.java:1653:in `each_slice'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:80:in `check_mail'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:69:in `run'
org/jruby/RubyProc.java:281:in `call'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.22/lib/stud/interval.rb:20:in `interval'
/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-imap-3.0.2/lib/logstash/inputs/imap.rb:68:in `run'
/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:425:in `inputworker'
/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:419:in `start_input'
^C12:45:02.701 [SIGINT handler] WARN  logstash.runner - SIGINT received. Shutting down the agent.
12:45:02.712 [Ruby-0-Thread-3: /usr/share/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.22/lib/stud/task.rb:22] DEBUG logstash.agent - Reading config file {:config_file=>"/home/dkimsey/mail.conf"}
12:45:02.714 [Ruby-0-Thread-3: /usr/share/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.22/lib/stud/task.rb:22] DEBUG logstash.agent - no configuration change for pipeline {:pipeline=>"main"}
12:45:03.717 [LogStash::Runner] DEBUG logstash.instrument.periodicpoller.os - PeriodicPoller: Stopping
```

Attached are sample headers from the messages that trigger this crash:
```
Return-Path: <donotreply@example.com>
Delivered-To: catchall@internal-relay.example.com
Received: (qmail 7338 invoked by alias); 12 Aug 2018 09:03:46 -0000
Delivered-To: alias-example@example.com
Received: (qmail 7335 invoked from network); 12 Aug 2018 09:03:46 -0000
Received: from server.example.com (10.70.250.244)
     by internal-relay.example.com with SMTP; 12 Aug 2018 09:03:46 -0000
Date: Sun, 12 Aug 2018 10:05:29 -0500 (CDT)
From: Example Support <donotreply@example.com>
To: Example Alias <alias@example.com>
Message-ID: <269f0a38-9e41-11e8-898f-490d1f59e2cc@server.example.com>
Subject: SIEM Case Needs Update: Case #1337
MIME-Version: 1.0
Content-Type: multipart/mixed; 
    	boundary="----=_Part_14178_1287706963.1534086329342"

------=_Part_14184_1527212999.1534086352336
Content-Type: multipart/related;
    boundary="----=_Part_14185_209084662.1534086352336"

------=_Part_14185_209084662.1534086352336
Content-Type: text/html;charset=UTF-8
Content-Transfer-Encoding: 7bit

<p>html was here</p>
------=_Part_14185_209084662.1534086352336--

------=_Part_14184_1527212999.1534086352336--
```

Possibly related to the issue reported in #25.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
