### PR TITLE
Add option to emit the unparsed RFC822 mail as the event message

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,6 +44,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-lowercase_headers>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-rfc822_mail>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-secure>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-strip_attachments>> |<<boolean,boolean>>|No
@@ -139,6 +140,14 @@ content-type as the event message.
   * There is no default value for this setting.
 
 
+
+[id="plugins-{type}s-{plugin}-rfc822_mail"]
+===== `rfc822_mail`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Emit the unparsed RFC822 mail as the event message.
 
 [id="plugins-{type}s-{plugin}-secure"]
 ===== `secure`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -148,6 +148,7 @@ content-type as the event message.
   * Default value is `false`
 
 Emit the unparsed RFC822 mail as the event message.
+NOTE: `strip_attachments` will be ignored if `rfc822_mail` is enabled.
 
 [id="plugins-{type}s-{plugin}-secure"]
 ===== `secure`
@@ -174,7 +175,7 @@ NOTE: it must be a file path and not a directory path.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-
+NOTE: `strip_attachments` will be ignored if `rfc822_mail` is enabled.
 
 [id="plugins-{type}s-{plugin}-uid_tracking"]
 ===== `uid_tracking`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -147,7 +147,11 @@ content-type as the event message.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Emit the unparsed RFC822 mail as the event message.
+Emit the unparsed RFC822 mail as the event message converted to UTF-8 using
+the `plain` codec and as the field `[@metadata][rfc822_mail]` in the original
+`ASCII-8BIT` encoding. Whenever non-UTF-8 mail is converted to UTF-8, 8-bit
+characters are corrupted. Therefore, the `[@metadata][rfc822_mail]` field must
+be used for further processing in the filters.
 NOTE: `strip_attachments` will be ignored if `rfc822_mail` is enabled.
 
 [id="plugins-{type}s-{plugin}-secure"]

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -73,6 +73,11 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       @logger.info("Loading \"uid_last_value\": \"#{@uid_last_value}\"")
     end
 
+    if @rfc822_mail
+      require "logstash/codecs/plain"
+      @codec = LogStash::Codecs::Plain.new("charset" => "ASCII-8BIT")
+    end
+
     @content_type_re = Regexp.new("^" + @content_type)
   end # def register
 
@@ -206,6 +211,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   def rfc822_mail(message)
     @codec.decode(message) do |event|
       decorate(event)
+      event.set('[@metadata][rfc822_mail]', message)
       event
     end
   end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -132,4 +132,16 @@ describe LogStash::Inputs::IMAP do
       insist { event.get("message") } == msg_text
     end
   end
+
+  context "when RFC822 mail is requested" do
+    it "should return unmodified mail" do
+      config = {"type" => "imap", "host" => "localhost",
+                "user" => "#{user}", "password" => "#{password}",
+                "rfc822_mail" => true}
+      input = LogStash::Inputs::IMAP.new config
+      input.register
+      event = input.rfc822_mail(subject.to_s)
+      insist { event.get("message") } == subject.to_s
+    end
+  end
 end


### PR DESCRIPTION
New option `rfc822_mail` emits unparsed RFC822 mail as event message so it can be processed by Logstash filters. This allows the processing of complex MIME types, such as RFC5969 Extensible Email Feedback Reports or RFC7489 DMARC Reports.