### PR TITLE
Added support for parsing mail in attachment

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-secure>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-mail_in_attachment>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-strip_attachments>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-verify_cert>> |<<boolean,boolean>>|No
@@ -146,8 +147,17 @@ content-type as the event message.
 
 
 
+[id="plugins-{type}s-{plugin}-mail_in_attachment"]
+===== `mail_in_attachment`
+
+  * Used when the relevant mail is delivered as an attachment in an encapsulating email
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+
+
 [id="plugins-{type}s-{plugin}-strip_attachments"]
-===== `strip_attachments` 
+===== `strip_attachments`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -28,8 +28,9 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   config :check_interval, :validate => :number, :default => 300
   config :delete, :validate => :boolean, :default => false
   config :expunge, :validate => :boolean, :default => false
+  config :mail_in_attachment, :validate => :boolean, :default => false
   config :strip_attachments, :validate => :boolean, :default => false
-  
+
   # For multipart messages, use the first part that has this
   # content-type as the event message.
   config :content_type, :validate => :string, :default => "text/plain"
@@ -106,6 +107,10 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   end
 
   def parse_mail(mail)
+    if @mail_in_attachment
+      attachment = mail.attachments.first.body
+      mail = Mail.new(attachment)
+    end
     # Add a debug message so we can track what message might cause an error later
     @logger.debug? && @logger.debug("Working with message_id", :message_id => mail.message_id)
     # TODO(sissel): What should a multipart message look like as an event?


### PR DESCRIPTION
This PR adds the option to treat the attachment as the actual email to be parsed, instead of the encapsulating email.
This is useful e.g. when handling bounces from email servers like PowerMTA, not matching their pattern matching, where the bounced message is attached as a file "email.txt" in an encapsulating email.