### PR TITLE
Added support for parsing mail in attachment

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,9 +45,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-secure>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-mail_in_attachment>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-strip_attachments>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-uid_tracking>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-verify_cert>> |<<boolean,boolean>>|No
 |=======================================================================
@@ -58,7 +57,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-check_interval"]
-===== `check_interval`
+===== `check_interval` 
 
   * Value type is <<number,number>>
   * Default value is `300`
@@ -66,7 +65,7 @@ input plugins.
 
 
 [id="plugins-{type}s-{plugin}-content_type"]
-===== `content_type`
+===== `content_type` 
 
   * Value type is <<string,string>>
   * Default value is `"text/plain"`
@@ -75,7 +74,7 @@ For multipart messages, use the first part that has this
 content-type as the event message.
 
 [id="plugins-{type}s-{plugin}-delete"]
-===== `delete`
+===== `delete` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -83,7 +82,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-expunge"]
-===== `expunge`
+===== `expunge` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -91,7 +90,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-fetch_count"]
-===== `fetch_count`
+===== `fetch_count` 
 
   * Value type is <<number,number>>
   * Default value is `50`
@@ -99,7 +98,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-folder"]
-===== `folder`
+===== `folder` 
 
   * Value type is <<string,string>>
   * Default value is `"INBOX"`
@@ -107,7 +106,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host`
+===== `host` 
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -116,7 +115,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-lowercase_headers"]
-===== `lowercase_headers`
+===== `lowercase_headers` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -124,7 +123,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password`
+===== `password` 
 
   * This is a required setting.
   * Value type is <<password,password>>
@@ -133,7 +132,7 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port`
+===== `port` 
 
   * Value type is <<number,number>>
   * There is no default value for this setting.
@@ -141,23 +140,21 @@ content-type as the event message.
 
 
 [id="plugins-{type}s-{plugin}-secure"]
-===== `secure`
+===== `secure` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 
 
-[id="plugins-{type}s-{plugin}-sincedb_path"]
-===== `sincedb_path`
+[id="plugins-{type}s-{plugin}-mail_in_attachment"]
+===== `mail_in_attachment`
 
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
+  * Used when the relevant mail is delivered as an attachment in an encapsulating email
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
 
-Path of the sincedb database file (keeps track of the UID of the last processed
-mail) that will be written to disk. The default will write sincedb file to
-`<path.data>/plugins/inputs/imap` directory.
-NOTE: it must be a file path and not a directory path.
+
 
 [id="plugins-{type}s-{plugin}-strip_attachments"]
 ===== `strip_attachments`
@@ -167,26 +164,8 @@ NOTE: it must be a file path and not a directory path.
 
 
 
-[id="plugins-{type}s-{plugin}-uid_tracking"]
-===== `uid_tracking`
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
-
-When the IMAP input plugin connects to the mailbox for the first time and
-the UID of the last processed mail is not yet known, the unread mails are
-first downloaded and the UID of the last processed mail is saved. From
-this point on, if `uid_tracking` is set to `true`, all new mail will be
-downloaded regardless of whether they are marked as read or unread. This
-allows users or other services to use the mailbox simultaneously with the
-IMAP input plugin. UID of the last processed mail is always saved regardles
-of the `uid_tracking` value, so you can switch its value as needed. In
-transition from the previous IMAP input plugin version, first process at least
-one mail with `uid_tracking` set to `false` to save the UID of the last
-processed mail and then switch `uid_tracking` to `true`.
-
 [id="plugins-{type}s-{plugin}-user"]
-===== `user`
+===== `user` 
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -195,7 +174,7 @@ processed mail and then switch `uid_tracking` to `true`.
 
 
 [id="plugins-{type}s-{plugin}-verify_cert"]
-===== `verify_cert`
+===== `verify_cert` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -3,6 +3,7 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/imap"
 require "mail"
 require "net/imap"
+require "base64"
 
 
 describe LogStash::Inputs::IMAP do
@@ -25,7 +26,7 @@ describe LogStash::Inputs::IMAP do
         allow(imap).to receive(:store)
         allow(ids).to receive(:each_slice).and_return([])
 
-        allow(imap).to receive(:uid_search).with("NOT SEEN").and_return(ids)
+        allow(imap).to receive(:search).with("NOT SEEN").and_return(ids)
         allow(Net::IMAP).to receive(:new).and_return(imap)
       end
     end
@@ -129,6 +130,33 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
+      insist { event.get("message") } == msg_text
+    end
+  end
+
+  context "when mail_in_attachment selected" do
+    it "should parse attachment as the actual mail" do
+      # Some servers forward mail as an attachment in an encapsulating mail.
+      # As an example, the server PowerMTA, delivers unmatched bounce messages,
+      # in a base64 encoded attachment, named "email.txt".
+      encapsulating_mail = Mail.new do
+        from     "mta@example.com"
+        to       "unmatched@example.com"
+        subject  "MTA unmatched message test"
+        date     Time.new
+        body     "The MTA could not recognize the attached message test"
+      end
+      encapsulating_mail.attachments['email.txt'] = {
+        :mime_type => 'text/plain', :content_transfer_encoding => 'base64',
+        :content => Base64.encode64(subject.to_s)
+      }
+      config = {"type" => "imap", "host" => "localhost",
+                "user" => "#{user}", "password" => "#{password}",
+                "mail_in_attachment" => "true"}
+
+      input = LogStash::Inputs::IMAP.new config
+      input.register
+      event = input.parse_mail(encapsulating_mail)
       insist { event.get("message") } == msg_text
     end
   end


### PR DESCRIPTION
This PR adds the option to treat the attachment as the actual email to be parsed, instead of the encapsulating email.
This is useful e.g. when handling bounces from email servers like PowerMTA, not matching their pattern matching, where the bounced message is attached as a file "email.txt" in an encapsulating email.