### PR TITLE
[TEST] Use OpenJDK8 instead of Oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ matrix:
   fast_finish: true
 install: true
 script: ci/build.sh
-jdk: oraclejdk8
+jdk: openjdk8
 before_install: gem install bundler -v '< 2'


### PR DESCRIPTION
Travis move to default distribution of Xenial means that builds can no
longer use oraclejdk8.

Testing to see if setting jdk to openjdk8 fixes the issue