### PR TITLE
Feature attachments

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-secure>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-save_attachments>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-strip_attachments>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-uid_tracking>> |<<boolean,boolean>>|No
@@ -146,7 +147,13 @@ content-type as the event message.
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
+[id="plugins-{type}s-{plugin}-save_attachments"]
+===== `save_attachments`
 
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to true the base64 content of attachments will be included in the `attachments.data` field.
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -153,7 +153,7 @@ content-type as the event message.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When set to true the base64 content of attachments will be included in the `attachments.data` field.
+When set to true the content of attachments will be included in the `attachments.data` field.
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -139,14 +139,6 @@ content-type as the event message.
   * Value type is <<number,number>>
   * There is no default value for this setting.
 
-
-
-[id="plugins-{type}s-{plugin}-secure"]
-===== `secure`
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
 [id="plugins-{type}s-{plugin}-save_attachments"]
 ===== `save_attachments`
 
@@ -154,6 +146,12 @@ content-type as the event message.
   * Default value is `false`
 
 When set to true the content of attachments will be included in the `attachments.data` field.
+
+[id="plugins-{type}s-{plugin}-secure"]
+===== `secure`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -152,7 +152,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
   def parse_attachments(mail)
     attachments = []
-    mail.all_parts.select{ |p| p.attachment?}.each do |attachment|
+    mail.attachments.each do |attachment|
       if @save_attachments
         attachments << { "filename" => attachment.filename, "data" => attachment.body.encoded }
       else

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -210,8 +210,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       end
 
       # Add attachments
-      if attachments.length > 0
-        event.set('attachments', attachments)
+      if attachments and attachments.length > 0
+        event.set('attachments', attachments) if
       end
 
       decorate(event)

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -210,7 +210,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       end
 
       # Add attachments
-      if attachments and attachments.length > 0
+      if attachments && attachments.length > 0
         event.set('attachments', attachments)
       end
 

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -211,7 +211,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
       # Add attachments
       if attachments and attachments.length > 0
-        event.set('attachments', attachments) if
+        event.set('attachments', attachments)
       end
 
       decorate(event)

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -156,7 +156,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
         attachments = find_attachments(part, attachments)
       end
     elsif parts.filename
-      attachment = { "filename": parts.filename }
+      attachment = { "filename" => parts.filename }
       if @save_attachments
         attachment['data'] = parts.body.encoded
       end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -135,7 +135,7 @@ describe LogStash::Inputs::IMAP do
     end
   end
 
-  context "with multiple attachments" do
+  context "with attachments" do
     it "should extract filenames" do
       config = {"type" => "imap", "host" => "localhost",
                 "user" => "#{user}", "password" => "#{password}"}

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -63,7 +63,6 @@ describe LogStash::Inputs::IMAP do
         input.register
         event = input.parse_mail(subject)
         insist { event.get("message") } == msg_text
-        puts subject
       end
     end
 

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -3,6 +3,7 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/imap"
 require "mail"
 require "net/imap"
+require "base64"
 
 
 describe LogStash::Inputs::IMAP do
@@ -40,6 +41,7 @@ describe LogStash::Inputs::IMAP do
   msg_text = "foo\nbar\nbaz"
   msg_html = "<p>a paragraph</p>\n\n"
   msg_binary = "\x42\x43\x44"
+  msg_unencoded = "raw text 🐐"
 
   subject do
     Mail.new do
@@ -50,6 +52,7 @@ describe LogStash::Inputs::IMAP do
       body     msg_text
       add_file :filename => "some.html", :content => msg_html
       add_file :filename => "image.png", :content => msg_binary
+      add_file :filename => "unencoded.data", :content => msg_unencoded, :content_transfer_encoding => "7bit"
     end
   end
 
@@ -143,10 +146,14 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("attachments") } == [{"filename"=>"some.html"}, {"filename"=>"image.png"}]
+      insist { event.get("attachments") } == [
+        {"filename"=>"some.html"},
+        {"filename"=>"image.png"},
+        {"filename"=>"unencoded.data"}
+      ]
     end
 
-    it "should extract the base64 content" do
+    it "should extract the encoded content" do
       config = {"type" => "imap", "host" => "localhost",
         "user" => "#{user}", "password" => "#{password}",
         "save_attachments" => true}
@@ -154,7 +161,11 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("attachments") } == [{"data"=>"PHA+YSBwYXJhZ3JhcGg8L3A+Cgo=\r\n", "filename"=>"some.html"}, {"data"=>"QkNE\r\n", "filename"=>"image.png"}]
+      insist { event.get("attachments") } == [
+        {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
+        {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
+        {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
+      ]
       end
   end
 end


### PR DESCRIPTION
Fixes #34 

This PR adds a couple of features:

1. It recursively searches the message parts for attachment and inline attachment filenames
2. If `save_attachments` is true it will dump the encoded (usually base64) contents as well

Example content:
```json
{
    ...
    "attachments": [
        {
            "filename": "test-document1.txt",
            "data": "MTI3LjAuMC4x\r\n"
        },
        {
            "filename": "test-attachment2.txt",
            "data": "dGhpcyBpcyBoZWxsbyB3b3JsZAo=\r\n"
        }
    ],
    ...
}
```

The attachment data can then be used by the [Elasticsearch Ingest Attachment Processor Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest-attachment-with-arrays.html). 

Something like:
```json
PUT _ingest/pipeline/test
{
  "description": "Extract attachment information from arrays",
  "processors": [{
      "foreach": {
        "field": "attachments",
        "processor": {
          "gsub": {
            "field": "_ingest._value.data",
            "pattern": "\\s",
            "replacement": ""
          }
        }
      }
    },
    {
      "foreach": {
        "field": "attachments",
        "processor": {
          "attachment": {
            "field": "_ingest._value.data",
            "target_field": "_ingest._value.attachment"
          }
        }
      }
    },
    {
      "foreach": {
        "field": "attachments",
        "processor": {
          "remove": {
            "field": "_ingest._value.data"
          }
        }
      }
    }
  ]
}
```