### PR TITLE
Feat: ECS compatibility (added headers_target and attachments_target)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
   - Feat: ECS compatibility [#55](https://github.com/logstash-plugins/logstash-input-imap/pull/55)
     * added (optional) `headers_target` configuration option
     * added (optional) `attachments_target` configuration option
-  - Fix: plugin should not close `$stdin`, while stoping
-  - Fix: make sure the 'Date' header is skipped regardless of the `lowercase_headers` setting 
+  - Fix: plugin should not close `$stdin`, while stoping 
 
 ## 3.1.0
   - Adds an option to recursively search the message parts for attachment and inline attachment filenames. If the save_attachments option is set to true, the content of attachments is included in the `attachments.data` field. The attachment data can then be used by the Elasticsearch Ingest Attachment Processor Plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
   - Feat: ECS compatibility [#55](https://github.com/logstash-plugins/logstash-input-imap/pull/55)
     * added (optional) `headers_target` configuration option
     * added (optional) `attachments_target` configuration option
-  - Fix: plugin should not close `$stdin`, while stoping 
+  - Fix: plugin should not close `$stdin`, while being stopped 
 
 ## 3.1.0
   - Adds an option to recursively search the message parts for attachment and inline attachment filenames. If the save_attachments option is set to true, the content of attachments is included in the `attachments.data` field. The attachment data can then be used by the Elasticsearch Ingest Attachment Processor Plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0
+  - Feat: ECS compatibility [#55](https://github.com/logstash-plugins/logstash-input-imap/pull/55)
+    * added (optional) `headers_target` configuration option
+    * added (optional) `attachments_target` configuration option
+  - Fix: plugin should not close `$stdin`, while stoping
+  - Fix: make sure the 'Date' header is skipped regardless of the `lowercase_headers` setting 
+
 ## 3.1.0
   - Adds an option to recursively search the message parts for attachment and inline attachment filenames. If the save_attachments option is set to true, the content of attachments is included in the `attachments.data` field. The attachment data can then be used by the Elasticsearch Ingest Attachment Processor Plugin.
   [#48](https://github.com/logstash-plugins/logstash-input-imap/pull/48)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,6 +26,7 @@ Read mails from IMAP server
 Periodically scan an IMAP folder (`INBOX` by default) and move any read messages
 to the trash.
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -149,7 +149,7 @@ The value of this setting affects the _default_ value of <<plugins-{type}s-{plug
   * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
     ** ECS Compatibility disabled: no default value for this setting
-    ** ECS Compatibility enabled: `"[@metadata][input][imap][headers]"
+    ** ECS Compatibility enabled: `"[@metadata][input][imap][headers]"`
 
 The name of the field under which mail headers will be added.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,6 +26,14 @@ Read mails from IMAP server
 Periodically scan an IMAP folder (`INBOX` by default) and move any read messages
 to the trash.
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
+When ECS compatibility is disabled, headers and attachments are targeted at the root level.
+When targeting an ECS versionn, headers and attachments target `@metadata` sub-fields unless configured otherwise in order
+to avoid conflict with ECS fields.
+See <<plugins-{type}s-{plugin}-headers_target>>, and <<plugins-{type}s-{plugin}-attachments_target>>.
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Imap Input Configuration Options
 
@@ -34,12 +42,15 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-attachments_target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-check_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-content_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-expunge>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-fetch_count>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-folder>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-headers_target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-lowercase_headers>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
@@ -58,6 +69,16 @@ input plugins.
 
 &nbsp;
 
+[id="plugins-{type}s-{plugin}-attachments_target"]
+===== `attachments_target`
+
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"[@metadata][input][imap][attachments]"
+
+The name of the field under which mail attachments information will be added, if <<plugins-{type}s-{plugin}-save_attachments>> is set.
+
 [id="plugins-{type}s-{plugin}-check_interval"]
 ===== `check_interval`
 
@@ -72,8 +93,7 @@ input plugins.
   * Value type is <<string,string>>
   * Default value is `"text/plain"`
 
-For multipart messages, use the first part that has this
-content-type as the event message.
+For multipart messages, use the first part that has this content-type as the event message.
 
 [id="plugins-{type}s-{plugin}-delete"]
 ===== `delete`
@@ -82,6 +102,21 @@ content-type as the event message.
   * Default value is `false`
 
 
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (for example, `From` header field is added to the event)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, the `From` header is added as metadata)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-headers_target>> and
+<<plugins-{type}s-{plugin}-attachments_target>>.
 
 [id="plugins-{type}s-{plugin}-expunge"]
 ===== `expunge`
@@ -106,6 +141,16 @@ content-type as the event message.
   * Default value is `"INBOX"`
 
 
+
+[id="plugins-{type}s-{plugin}-headers_target"]
+===== `headers_target`
+
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"[@metadata][input][imap][headers]"
+
+The name of the field under which mail headers will be added.
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -75,7 +75,7 @@ input plugins.
 
   * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
-    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility disabled: `"[attachments]"`
     ** ECS Compatibility enabled: `"[@metadata][input][imap][attachments]"
 
 The name of the field under which mail attachments information will be added, if <<plugins-{type}s-{plugin}-save_attachments>> is set.
@@ -148,10 +148,13 @@ The value of this setting affects the _default_ value of <<plugins-{type}s-{plug
 
   * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
-    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility disabled: no default value (for example, the subject header is stored under the `"subject"` name)
     ** ECS Compatibility enabled: `"[@metadata][input][imap][headers]"`
 
 The name of the field under which mail headers will be added.
+
+Setting `headers_target => ''` skips headers processing and no header is added to the event.
+Except the date header, if present, which is always used as the event's `@timestamp`.
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -29,8 +29,8 @@ to the trash.
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
-When ECS compatibility is disabled, headers and attachments are targeted at the root level.
-When targeting an ECS versionn, headers and attachments target `@metadata` sub-fields unless configured otherwise in order
+When ECS compatibility is disabled, mail headers and attachments are targeted at the root level.
+When targeting an ECS version, headers and attachments target `@metadata` sub-fields unless configured otherwise in order
 to avoid conflict with ECS fields.
 See <<plugins-{type}s-{plugin}-headers_target>>, and <<plugins-{type}s-{plugin}-attachments_target>>.
 

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -238,7 +238,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
         # Details at:
         #   https://github.com/mikel/mail/blob/master/README.md#encodings
         #   http://tools.ietf.org/html/rfc2047#section-2
-        value = transcode_to_utf8(header.decoded.to_s)
+        value = transcode_to_utf8(header.decoded)
 
         targeted_name = "#{@headers_target}[#{name}]"
         case (field = event.get(targeted_name))
@@ -273,8 +273,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   # the mail gem will set the correct encoding on header strings decoding
   # and we want to transcode it to utf8
   def transcode_to_utf8(s)
-    unless s.nil?
-      s.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
-    end
+    return nil if s.nil?
+    s.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
   end
 end

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -23,15 +23,17 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
   config :folder, :validate => :string, :default => 'INBOX'
   config :fetch_count, :validate => :number, :default => 50
-  config :lowercase_headers, :validate => :boolean, :default => true
   config :check_interval, :validate => :number, :default => 300
+
+  config :lowercase_headers, :validate => :boolean, :default => true
+
   config :delete, :validate => :boolean, :default => false
   config :expunge, :validate => :boolean, :default => false
+
   config :strip_attachments, :validate => :boolean, :default => false
   config :save_attachments, :validate => :boolean, :default => false
 
-  # For multipart messages, use the first part that has this
-  # content-type as the event message.
+  # For multipart messages, use the first part that has this content-type as the event message.
   config :content_type, :validate => :string, :default => "text/plain"
 
   # Whether to use IMAP uid to track last processed message

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -62,18 +62,21 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
     super
 
     if original_params.include?('headers_target')
-      @headers_target = normalize_field_ref(@headers_target)
+      @headers_target = normalize_field_ref(headers_target)
     else
+      # NOTE: user specified `headers_target => ''` means disable headers (@headers_target == nil)
+      # unlike our default here (@headers_target == '') causes setting headers at top level ...
       @headers_target = ecs_compatibility != :disabled ? '[@metadata][input][imap][headers]' : ''
     end
 
     if original_params.include?('attachments_target')
-      @attachments_target = normalize_field_ref(@attachments_target)
+      @attachments_target = normalize_field_ref(attachments_target)
     else
       @attachments_target = ecs_compatibility != :disabled ? '[@metadata][input][imap][attachments]' : '[attachments]'
     end
   end
 
+  # @note a '' target value is normalized to nil
   def normalize_field_ref(target)
     return nil if target.nil? || target.empty?
     # so we can later event.set("#{target}[#{name}]", ...)

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "logstash/timestamp"
 require "stud/interval"
+require 'fileutils'
 
 # Read mails from IMAP server
 #

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -228,7 +228,6 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
   def stop
     Stud.stop!(@run_thread)
-    $stdin.close
   end
 
   private

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -104,12 +104,11 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       @sincedb_path = File.join(datapath, ".sincedb_" + Digest::MD5.hexdigest("#{@user}_#{@host}_#{@port}_#{@folder}"))
       @logger.debug? && @logger.debug("Generated sincedb path", sincedb_path: @sincedb_path)
     end
-
+    @logger.info("Using", sincedb_path: @sincedb_path)
     if File.exist?(@sincedb_path)
       if File.directory?(@sincedb_path)
         raise ArgumentError.new("The \"sincedb_path\" argument must point to a file, received a directory: \"#{@sincedb_path}\"")
       end
-      @logger.debug? && @logger.debug("Found existing sincedb path", sincedb_path: @sincedb_path)
       @uid_last_value = File.read(@sincedb_path).to_i
       @logger.debug? && @logger.debug("Loaded from sincedb", uid_last_value: @uid_last_value)
     end

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -244,10 +244,6 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
     mail.header_fields.each do |header|
       # 'header.name' can sometimes be a Mail::Multibyte::Chars, get it in String form
       name = header.name.to_s
-
-      # assume we already processed the 'date' into event.timestamp
-      next if name == "Date"
-
       name = name.downcase if @lowercase_headers
 
       # Call .decoded on the header in case it's in encoded-word form.

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -3,7 +3,6 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "logstash/timestamp"
 require "stud/interval"
-require "socket" # for Socket.gethostname
 
 # Read mails from IMAP server
 #

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -176,7 +176,6 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   rescue => e
     @logger.error("Encountered error #{e.class}", :message => e.message, :backtrace => e.backtrace)
     # Do not raise error, check_mail will be invoked in the next run time
-
   ensure
     # Close the connection (and ignore errors)
     imap.close rescue nil
@@ -224,34 +223,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       # Use the 'Date' field as the timestamp
       event.timestamp = LogStash::Timestamp.new(mail.date.to_time)
 
-      # Add fields: Add message.header_fields { |h| h.name=> h.value }
-      mail.header_fields.each do |header|
-        # 'header.name' can sometimes be a Mail::Multibyte::Chars, get it in String form
-        name = header.name.to_s
-
-        # Assume we already processed the 'date' above.
-        next if name == "Date"
-
-        name = name.downcase if @lowercase_headers
-
-        # Call .decoded on the header in case it's in encoded-word form.
-        # Details at:
-        #   https://github.com/mikel/mail/blob/master/README.md#encodings
-        #   http://tools.ietf.org/html/rfc2047#section-2
-        value = transcode_to_utf8(header.decoded)
-
-        targeted_name = "#{@headers_target}[#{name}]"
-        case (field = event.get(targeted_name))
-        when String
-          # promote string to array if a header appears multiple times (like 'received')
-          event.set(targeted_name, [field, value])
-        when Array
-          field << value
-          event.set(targeted_name, field)
-        when nil
-          event.set(targeted_name, value)
-        end
-      end
+      process_headers(mail, event)
 
       # Add attachments
       if attachments && attachments.length > 0
@@ -260,6 +232,37 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
       decorate(event)
       event
+    end
+  end
+
+  def process_headers(mail, event)
+    # Add fields: Add message.header_fields { |h| h.name=> h.value }
+    mail.header_fields.each do |header|
+      # 'header.name' can sometimes be a Mail::Multibyte::Chars, get it in String form
+      name = header.name.to_s
+
+      # assume we already processed the 'date' into event.timestamp
+      next if name == "Date"
+
+      name = name.downcase if @lowercase_headers
+
+      # Call .decoded on the header in case it's in encoded-word form.
+      # Details at:
+      #   https://github.com/mikel/mail/blob/master/README.md#encodings
+      #   http://tools.ietf.org/html/rfc2047#section-2
+      value = transcode_to_utf8(header.decoded)
+
+      targeted_name = "#{@headers_target}[#{name}]"
+      case (field = event.get(targeted_name))
+      when String
+        # promote string to array if a header appears multiple times (like 'received')
+        event.set(targeted_name, [field, value])
+      when Array
+        field << value
+        event.set(targeted_name, field)
+      when nil
+        event.set(targeted_name, value)
+      end
     end
   end
 

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -185,15 +185,18 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       # Add fields: Add message.header_fields { |h| h.name=> h.value }
       mail.header_fields.each do |header|
         # 'header.name' can sometimes be a Mail::Multibyte::Chars, get it in String form
-        name = @lowercase_headers ? header.name.to_s.downcase : header.name.to_s
+        name = header.name.to_s
+
+        # Assume we already processed the 'date' above.
+        next if name == "Date"
+
+        name = name.downcase if @lowercase_headers
+
         # Call .decoded on the header in case it's in encoded-word form.
         # Details at:
         #   https://github.com/mikel/mail/blob/master/README.md#encodings
         #   http://tools.ietf.org/html/rfc2047#section-2
         value = transcode_to_utf8(header.decoded.to_s)
-
-        # Assume we already processed the 'date' above.
-        next if name == "Date"
 
         case (field = event.get(name))
         when String

--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'mail', '~> 2.6.3'
   s.add_runtime_dependency 'mime-types', '2.6.2'

--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-imap'
-  s.version         = '3.1.0'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads mail from an IMAP server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'insist'
 end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/devutils/rspec/shared_examples"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require "logstash/inputs/imap"
 require "mail"
 require "net/imap"
@@ -34,7 +35,7 @@ describe LogStash::Inputs::IMAP do
 
 end
 
-describe LogStash::Inputs::IMAP do
+describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
   user = "logstash"
   password = "secret"
   msg_time = Time.new
@@ -78,127 +79,174 @@ describe LogStash::Inputs::IMAP do
     input.register
   end
 
-  context "when no content-type selected" do
-    it "should select text/plain part" do
-      event = input.parse_mail(mail)
-      expect( event.get("message") ).to eql msg_text
-    end
-  end
+  ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
-  context "when text/html content-type selected" do
-    let(:config) { super().merge("content_type" => "text/html") }
+    let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
 
-    it "should select text/html part" do
-      event = input.parse_mail(mail)
-      expect( event.get("message") ).to eql msg_html
-    end
-  end
+    let (:config) { super().merge('ecs_compatibility' => ecs_select.active_mode) }
 
-  context "mail headers" do
-    let(:config) { super().merge("lowercase_headers" => true) } # default
-
-    before { @event = input.parse_mail(mail) }
-
-    it "sets all header fields" do
-      expect( @event.get("x-spam-category") ).to eql 'LEGIT'
-      expect( @event.get("x-aes-category") ).to eql 'LEGIT'
-      expect( @event.get("x-bot-id") ).to eql '111'
-      ['spam-stopper-id', 'spam-stopper-v2', 'x-mimeole', 'message-id', 'x-priority'].each do |name|
-        expect( @event.include?(name) ).to be true
+    context "when no content-type selected" do
+      it "should select text/plain part" do
+        event = input.parse_mail(mail)
+        expect( event.get("message") ).to eql msg_text
       end
-      expect( @event.get("from") ).to eql 'me@example.com'
-      expect( @event.get("to") ).to eql 'you@example.com'
-      expect( @event.get("subject") ).to eql 'logstash imap input test'
     end
 
-    it 'does not set date header' do
-      expect( @event.include?('date') ).to be false
-      expect( @event.include?('Date') ).to be false
-    end
-  end
+    context "when text/html content-type selected" do
+      let(:config) { super().merge("content_type" => "text/html") }
 
-  context "mail headers (not lower-cased)" do
-    let(:config) { super().merge("lowercase_headers" => false) }
-
-    before { @event = input.parse_mail(mail) }
-
-    it "sets all header fields" do
-      expect( @event.get("X-Spam-Category") ).to eql 'LEGIT'
-      expect( @event.get("X-AES-Category") ).to eql 'LEGIT'
-      expect( @event.get("X-Bot-ID") ).to eql '111'
-      ['Spam-Stopper-Id', 'Spam-Stopper-v2', 'X-MimeOLE', 'Message-ID', 'X-Priority'].each do |name|
-        expect( @event.include?(name) ).to be true
+      it "should select text/html part" do
+        event = input.parse_mail(mail)
+        expect( event.get("message") ).to eql msg_html
       end
-      expect( @event.get("From") ).to eql 'me@example.com'
-      expect( @event.get("To") ).to eql 'you@example.com'
-      expect( @event.get("Subject") ).to eql 'logstash imap input test'
     end
 
-    it 'does not set date header' do
-      expect( @event.include?('Date') ).to be false
+    context "mail headers" do
+      let(:config) { super().merge("lowercase_headers" => true) } # default
+
+      before { @event = input.parse_mail(mail) }
+
+      it "sets all header fields" do
+        if ecs_compatibility?
+          expect( @event.get("[@metadata][input][imap][headers][x-spam-category]") ).to eql 'LEGIT'
+          expect( @event.get("[@metadata][input][imap][headers][x-aes-category]") ).to eql 'LEGIT'
+          expect( @event.get("[@metadata][input][imap][headers][x-bot-id]") ).to eql '111'
+          ['spam-stopper-id', 'spam-stopper-v2', 'x-mimeole', 'message-id', 'x-priority'].each do |name|
+            expect( @event.include?("[@metadata][input][imap][headers][#{name}]") ).to be true
+          end
+          expect( @event.get("[@metadata][input][imap][headers][from]") ).to eql 'me@example.com'
+          expect( @event.get("[@metadata][input][imap][headers][to]") ).to eql 'you@example.com'
+          expect( @event.get("[@metadata][input][imap][headers][subject]") ).to eql 'logstash imap input test'
+        else
+          expect( @event.get("x-spam-category") ).to eql 'LEGIT'
+          expect( @event.get("x-aes-category") ).to eql 'LEGIT'
+          expect( @event.get("x-bot-id") ).to eql '111'
+          ['spam-stopper-id', 'spam-stopper-v2', 'x-mimeole', 'message-id', 'x-priority'].each do |name|
+            expect( @event.include?(name) ).to be true
+          end
+          expect( @event.get("from") ).to eql 'me@example.com'
+          expect( @event.get("to") ).to eql 'you@example.com'
+          expect( @event.get("subject") ).to eql 'logstash imap input test'
+        end
+      end
+
+      it 'does not set date header' do
+        expect( @event.include?('date') ).to be false
+        expect( @event.include?('Date') ).to be false
+      end
     end
+
+    context "mail headers (not lower-cased)" do
+      let(:config) { super().merge("lowercase_headers" => false) }
+
+      before { @event = input.parse_mail(mail) }
+
+      it "sets all header fields" do
+        if ecs_compatibility?
+          expect( @event.get("[@metadata][input][imap][headers][X-Spam-Category]") ).to eql 'LEGIT'
+          expect( @event.get("[@metadata][input][imap][headers][X-AES-Category]") ).to eql 'LEGIT'
+          expect( @event.get("[@metadata][input][imap][headers][X-Bot-ID]") ).to eql '111'
+          ['Spam-Stopper-Id', 'Spam-Stopper-v2', 'X-MimeOLE', 'Message-ID', 'X-Priority'].each do |name|
+            expect( @event.include?("[@metadata][input][imap][headers][#{name}]") ).to be true
+          end
+          expect( @event.get("[@metadata][input][imap][headers][From]") ).to eql 'me@example.com'
+          expect( @event.get("[@metadata][input][imap][headers][To]") ).to eql 'you@example.com'
+          expect( @event.get("[@metadata][input][imap][headers][Subject]") ).to eql 'logstash imap input test'
+        else
+          expect( @event.get("X-Spam-Category") ).to eql 'LEGIT'
+          expect( @event.get("X-AES-Category") ).to eql 'LEGIT'
+          expect( @event.get("X-Bot-ID") ).to eql '111'
+          ['Spam-Stopper-Id', 'Spam-Stopper-v2', 'X-MimeOLE', 'Message-ID', 'X-Priority'].each do |name|
+            expect( @event.include?(name) ).to be true
+          end
+          expect( @event.get("From") ).to eql 'me@example.com'
+          expect( @event.get("To") ).to eql 'you@example.com'
+          expect( @event.get("Subject") ).to eql 'logstash imap input test'
+        end
+      end
+
+      it 'does not set date header' do
+        expect( @event.include?('Date') ).to be false
+      end
+    end
+
+    context "when subject is in RFC 2047 encoded-word format" do
+      before do
+        mail.subject = "=?iso-8859-1?Q?foo_:_bar?="
+      end
+
+      it "should be decoded" do
+        event = input.parse_mail(mail)
+        if ecs_compatibility?
+          expect( event.get("[@metadata][input][imap][headers][subject]") ).to eql "foo : bar"
+        else
+          expect( event.get("subject") ).to eql "foo : bar"
+        end
+      end
+    end
+
+    context "with multiple values for same header" do
+      it "should add 2 values as array in event" do
+        mail.received = "test1"
+        mail.received = "test2"
+
+        event = input.parse_mail(mail)
+        expected_value = ["test1", "test2"]
+        if ecs_compatibility?
+          expect( event.get("[@metadata][input][imap][headers][received]") ).to eql expected_value
+        else
+          expect( event.get("received") ).to eql expected_value
+        end
+      end
+
+      it "should add more than 2 values as array in event" do
+        mail.received = "test1"
+        mail.received = "test2"
+        mail.received = "test3"
+
+        event = input.parse_mail(mail)
+        expected_value = ["test1", "test2", "test3"]
+        if ecs_compatibility?
+          expect( event.get("[@metadata][input][imap][headers][received]") ).to eql expected_value
+        else
+          expect( event.get("received") ).to eql expected_value
+        end
+      end
+    end
+
+    context "when a header field is nil" do
+      it "should parse mail" do
+        mail.header['X-Custom-Header'] = nil
+
+        event = input.parse_mail(mail)
+        expect( event.get("message") ).to eql msg_text
+      end
+    end
+
+    context "attachments" do
+      it "should extract filenames" do
+        event = input.parse_mail(mail)
+        expect( event.get("attachments") ).to eql [
+                                                      {"filename"=>"some.html"},
+                                                      {"filename"=>"image.png"},
+                                                      {"filename"=>"unencoded.data"}
+                                                  ]
+      end
+    end
+
+    context "with attachments saving" do
+      let(:config) { super().merge("save_attachments" => true) }
+
+      it "should extract the encoded content" do
+        event = input.parse_mail(mail)
+        expect( event.get("attachments") ).to eql [
+                                                      {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
+                                                      {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
+                                                      {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
+                                                  ]
+      end
+    end
+
   end
 
-  context "when subject is in RFC 2047 encoded-word format" do
-    before do
-      mail.subject = "=?iso-8859-1?Q?foo_:_bar?="
-    end
-
-    it "should be decoded" do
-      event = input.parse_mail(mail)
-      expect( event.get("subject") ).to eql "foo : bar"
-    end
-  end
-
-  context "with multiple values for same header" do
-    it "should add 2 values as array in event" do
-      mail.received = "test1"
-      mail.received = "test2"
-
-      event = input.parse_mail(mail)
-      expect( event.get("received") ).to eql ["test1", "test2"]
-    end
-
-    it "should add more than 2 values as array in event" do
-      mail.received = "test1"
-      mail.received = "test2"
-      mail.received = "test3"
-
-      event = input.parse_mail(mail)
-      expect( event.get("received") ).to eql ["test1", "test2", "test3"]
-    end
-  end
-
-  context "when a header field is nil" do
-    it "should parse mail" do
-      mail.header['X-Custom-Header'] = nil
-
-      event = input.parse_mail(mail)
-      expect( event.get("message") ).to eql msg_text
-    end
-  end
-
-  context "attachments" do
-    it "should extract filenames" do
-      event = input.parse_mail(mail)
-      expect( event.get("attachments") ).to eql [
-        {"filename"=>"some.html"},
-        {"filename"=>"image.png"},
-        {"filename"=>"unencoded.data"}
-      ]
-    end
-  end
-
-  context "with attachments saving" do
-    let(:config) { super().merge("save_attachments" => true) }
-
-    it "should extract the encoded content" do
-      event = input.parse_mail(mail)
-      expect( event.get("attachments") ).to eql [
-                                                    {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
-                                                    {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
-                                                    {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
-                                                ]
-    end
-  end
 end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -170,6 +170,19 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
       end
     end
 
+    context "headers_target => ''" do
+      let(:config) { super().merge("headers_target" => '') }
+
+      before { @event = input.parse_mail(mail) }
+
+      it "does not set any header fields" do
+        ['From', 'To', 'Subject', 'subject', 'Date', 'date'].each do |name|
+          expect( @event.include?(name) ).to be false # legacy
+          expect( @event.include?("[@metadata][input][imap][headers][#{name}]") ).to be false # ecs
+        end
+      end
+    end
+
     context "when subject is in RFC 2047 encoded-word format" do
       before do
         mail.subject = "=?iso-8859-1?Q?foo_:_bar?="

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
-require "insist"
 require "logstash/devutils/rspec/shared_examples"
 require "logstash/inputs/imap"
 require "mail"
 require "net/imap"
 require "base64"
-
 
 describe LogStash::Inputs::IMAP do
 
@@ -67,7 +65,7 @@ describe LogStash::Inputs::IMAP do
         input = LogStash::Inputs::IMAP.new config
         input.register
         event = input.parse_mail(subject)
-        insist { event.get("message") } == msg_text
+        expect( event.get("message") ).to eql msg_text
       end
     end
 
@@ -80,7 +78,7 @@ describe LogStash::Inputs::IMAP do
         input = LogStash::Inputs::IMAP.new config
         input.register
         event = input.parse_mail(subject)
-        insist { event.get("message") } == msg_html
+        expect( event.get("message") ).to eql msg_html
       end
     end
   end
@@ -94,7 +92,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("subject") } == "foo : bar"
+      expect( event.get("subject") ).to eql "foo : bar"
     end
   end
 
@@ -109,7 +107,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("received") } == ["test1", "test2"]
+      expect( event.get("received") ).to eql ["test1", "test2"]
     end
 
     it "should add more than 2 values as array in event" do
@@ -123,7 +121,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("received") } == ["test1", "test2", "test3"]
+      expect( event.get("received") ).to eql ["test1", "test2", "test3"]
     end
   end
 
@@ -136,7 +134,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("message") } == msg_text
+      expect( event.get("message") ).to eql msg_text
     end
   end
 
@@ -148,7 +146,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("attachments") } == [
+      expect( event.get("attachments") ).to eql [
         {"filename"=>"some.html"},
         {"filename"=>"image.png"},
         {"filename"=>"unencoded.data"}
@@ -163,7 +161,7 @@ describe LogStash::Inputs::IMAP do
       input = LogStash::Inputs::IMAP.new config
       input.register
       event = input.parse_mail(subject)
-      insist { event.get("attachments") } == [
+      expect( event.get("attachments") ).to eql [
         {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
         {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
         {"data"=> msg_unencoded, "filename"=>"unencoded.data"}

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -43,129 +43,162 @@ describe LogStash::Inputs::IMAP do
   msg_binary = "\x42\x43\x44"
   msg_unencoded = "raw text 🐐"
 
-  subject do
+  let(:config) do
+    { "host" => "localhost", "user" => "#{user}", "password" => "#{password}" }
+  end
+
+  subject(:input) do
+    LogStash::Inputs::IMAP.new config
+  end
+
+  let(:mail) do
     Mail.new do
       from     "me@example.com"
       to       "you@example.com"
       subject  "logstash imap input test"
       date     msg_time
       body     msg_text
+      message_id '<123@message.id>' # 'Message-ID' header
+      # let's have some headers:
+      header['X-Priority'] = '3'
+      header['X-Bot-ID'] = '111'
+      header['X-AES-Category'] = 'LEGIT'
+      header['X-Spam-Category'] = 'LEGIT'
+      header['Spam-Stopper-Id'] = '464bbb1a-1b86-4006-8a09-ce797fb56346'
+      header['Spam-Stopper-v2'] = 'Yes'
+      header['X-Mailer'] = 'Microsoft Outlook Express 6.00.2800.1106'
+      header['X-MimeOLE'] = 'Produced By Microsoft MimeOLE V6.00.2800.1106'
       add_file :filename => "some.html", :content => msg_html
       add_file :filename => "image.png", :content => msg_binary
       add_file :filename => "unencoded.data", :content => msg_unencoded, :content_transfer_encoding => "7bit"
     end
   end
 
-  context "with both text and html parts" do
-    context "when no content-type selected" do
-      it "should select text/plain part" do
-        config = {"type" => "imap", "host" => "localhost",
-                  "user" => "#{user}", "password" => "#{password}"}
+  before do
+    input.register
+  end
 
-        input = LogStash::Inputs::IMAP.new config
-        input.register
-        event = input.parse_mail(subject)
-        expect( event.get("message") ).to eql msg_text
+  context "when no content-type selected" do
+    it "should select text/plain part" do
+      event = input.parse_mail(mail)
+      expect( event.get("message") ).to eql msg_text
+    end
+  end
+
+  context "when text/html content-type selected" do
+    let(:config) { super().merge("content_type" => "text/html") }
+
+    it "should select text/html part" do
+      event = input.parse_mail(mail)
+      expect( event.get("message") ).to eql msg_html
+    end
+  end
+
+  context "mail headers" do
+    let(:config) { super().merge("lowercase_headers" => true) } # default
+
+    before { @event = input.parse_mail(mail) }
+
+    it "sets all header fields" do
+      expect( @event.get("x-spam-category") ).to eql 'LEGIT'
+      expect( @event.get("x-aes-category") ).to eql 'LEGIT'
+      expect( @event.get("x-bot-id") ).to eql '111'
+      ['spam-stopper-id', 'spam-stopper-v2', 'x-mimeole', 'message-id', 'x-priority'].each do |name|
+        expect( @event.include?(name) ).to be true
       end
+      expect( @event.get("from") ).to eql 'me@example.com'
+      expect( @event.get("to") ).to eql 'you@example.com'
+      expect( @event.get("subject") ).to eql 'logstash imap input test'
     end
 
-    context "when text/html content-type selected" do
-      it "should select text/html part" do
-        config = {"type" => "imap", "host" => "localhost",
-                  "user" => "#{user}", "password" => "#{password}",
-                  "content_type" => "text/html"}
+    it 'does not set date header' do
+      expect( @event.include?('date') ).to be false
+      expect( @event.include?('Date') ).to be false
+    end
+  end
 
-        input = LogStash::Inputs::IMAP.new config
-        input.register
-        event = input.parse_mail(subject)
-        expect( event.get("message") ).to eql msg_html
+  context "mail headers (not lower-cased)" do
+    let(:config) { super().merge("lowercase_headers" => false) }
+
+    before { @event = input.parse_mail(mail) }
+
+    it "sets all header fields" do
+      expect( @event.get("X-Spam-Category") ).to eql 'LEGIT'
+      expect( @event.get("X-AES-Category") ).to eql 'LEGIT'
+      expect( @event.get("X-Bot-ID") ).to eql '111'
+      ['Spam-Stopper-Id', 'Spam-Stopper-v2', 'X-MimeOLE', 'Message-ID', 'X-Priority'].each do |name|
+        expect( @event.include?(name) ).to be true
       end
+      expect( @event.get("From") ).to eql 'me@example.com'
+      expect( @event.get("To") ).to eql 'you@example.com'
+      expect( @event.get("Subject") ).to eql 'logstash imap input test'
+    end
+
+    it 'does not set date header' do
+      expect( @event.include?('Date') ).to be false
     end
   end
 
   context "when subject is in RFC 2047 encoded-word format" do
-    it "should be decoded" do
-      subject.subject = "=?iso-8859-1?Q?foo_:_bar?="
-      config = {"type" => "imap", "host" => "localhost",
-                "user" => "#{user}", "password" => "#{password}"}
+    before do
+      mail.subject = "=?iso-8859-1?Q?foo_:_bar?="
+    end
 
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+    it "should be decoded" do
+      event = input.parse_mail(mail)
       expect( event.get("subject") ).to eql "foo : bar"
     end
   end
 
   context "with multiple values for same header" do
     it "should add 2 values as array in event" do
-      subject.received = "test1"
-      subject.received = "test2"
+      mail.received = "test1"
+      mail.received = "test2"
 
-      config = {"type" => "imap", "host" => "localhost",
-                "user" => "#{user}", "password" => "#{password}"}
-
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+      event = input.parse_mail(mail)
       expect( event.get("received") ).to eql ["test1", "test2"]
     end
 
     it "should add more than 2 values as array in event" do
-      subject.received = "test1"
-      subject.received = "test2"
-      subject.received = "test3"
+      mail.received = "test1"
+      mail.received = "test2"
+      mail.received = "test3"
 
-      config = {"type" => "imap", "host" => "localhost",
-                "user" => "#{user}", "password" => "#{password}"}
-
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+      event = input.parse_mail(mail)
       expect( event.get("received") ).to eql ["test1", "test2", "test3"]
     end
   end
 
   context "when a header field is nil" do
     it "should parse mail" do
-      subject.header['X-Custom-Header'] = nil
-      config = {"type" => "imap", "host" => "localhost",
-                "user" => "#{user}", "password" => "#{password}"}
+      mail.header['X-Custom-Header'] = nil
 
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+      event = input.parse_mail(mail)
       expect( event.get("message") ).to eql msg_text
     end
   end
 
-  context "with attachments" do
+  context "attachments" do
     it "should extract filenames" do
-      config = {"type" => "imap", "host" => "localhost",
-                "user" => "#{user}", "password" => "#{password}"}
-
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+      event = input.parse_mail(mail)
       expect( event.get("attachments") ).to eql [
         {"filename"=>"some.html"},
         {"filename"=>"image.png"},
         {"filename"=>"unencoded.data"}
       ]
     end
+  end
+
+  context "with attachments saving" do
+    let(:config) { super().merge("save_attachments" => true) }
 
     it "should extract the encoded content" do
-      config = {"type" => "imap", "host" => "localhost",
-        "user" => "#{user}", "password" => "#{password}",
-        "save_attachments" => true}
-
-      input = LogStash::Inputs::IMAP.new config
-      input.register
-      event = input.parse_mail(subject)
+      event = input.parse_mail(mail)
       expect( event.get("attachments") ).to eql [
-        {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
-        {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
-        {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
-      ]
-      end
+                                                    {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
+                                                    {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
+                                                    {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
+                                                ]
+    end
   end
 end

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -130,8 +130,8 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
         end
       end
 
-      it 'does not set date header' do
-        expect( @event.include?('date') ).to be false
+      it 'does include the date header' do
+        expect( @event.include?('date') ).to be true unless ecs_compatibility?
         expect( @event.include?('Date') ).to be false
       end
     end
@@ -165,8 +165,8 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
         end
       end
 
-      it 'does not set date header' do
-        expect( @event.include?('Date') ).to be false
+      it 'does include the date header' do
+        expect( @event.include?('Date') ).to be true unless ecs_compatibility?
       end
     end
 

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -226,11 +226,12 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
     context "attachments" do
       it "should extract filenames" do
         event = input.parse_mail(mail)
-        expect( event.get("attachments") ).to eql [
-                                                      {"filename"=>"some.html"},
-                                                      {"filename"=>"image.png"},
-                                                      {"filename"=>"unencoded.data"}
-                                                  ]
+        target = ecs_compatibility? ? '[@metadata][input][imap][attachments]' : 'attachments'
+        expect( event.get(target) ).to eql [
+                                                {"filename"=>"some.html"},
+                                                {"filename"=>"image.png"},
+                                                {"filename"=>"unencoded.data"}
+                                            ]
       end
     end
 
@@ -239,11 +240,12 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
 
       it "should extract the encoded content" do
         event = input.parse_mail(mail)
-        expect( event.get("attachments") ).to eql [
-                                                      {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
-                                                      {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
-                                                      {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
-                                                  ]
+        target = ecs_compatibility? ? '[@metadata][input][imap][attachments]' : 'attachments'
+        expect( event.get(target) ).to eql [
+                                                {"data"=> Base64.encode64(msg_html).encode(crlf_newline: true), "filename"=>"some.html"},
+                                                {"data"=> Base64.encode64(msg_binary).encode(crlf_newline: true), "filename"=>"image.png"},
+                                                {"data"=> msg_unencoded, "filename"=>"unencoded.data"}
+                                            ]
       end
     end
 


### PR DESCRIPTION
When ECS compatibility is disabled, mail headers and attachments are targeted at the root level.
When targeting an ECS versionn, headers and attachments target `@metadata` sub-fields unless configured otherwise in order
to avoid conflict with ECS fields. 

This is achieved by having 2 new options: 
1. `headers_target` (for header names e.g. `"From"`, `"Subject"`, `"X-Spam-Score"`)
2. `attachments_target`

NOTE: headers are lower-cased by default, this settings stays the same in ECS mode. 
Further, decided NOT to `tr('-', '_')` as an attempt to under_score names e.g. `"X-Spam-Score"` -> `"x_spam_score"`, this would likely need another configuration option to maintain backwards compatibility (things could get a bit out of hand with multiple things changing due ECS mode).

---

There's an [RFC for providing `email.*` fields in ECS](https://github.com/elastic/ecs/pull/1593/files), this isn't part of the PR, however there's a [draft](https://github.com/logstash-plugins/logstash-input-imap/pull/56) waiting for the RFC to become stable or at least the stage 2 RFC to get pushed (e.g. as these changes were developed the RFC [changed the mapping](https://github.com/elastic/ecs/pull/1593/commits/aeb8b7e2da67ff6584f3c1bde3024a5fbd02a1fc) in a way that would have created ECS conflicts).

---

Also includes some minor fixes that came along the way, notably the `Date` header is no longer skipped as that only worked when `lowercase_headers => false` was specified.
