### PR TITLE
Fixes #6

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -225,7 +225,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
 
     @codec.decode(message) do |event|
       # Use the 'Date' field as the timestamp
-      event.timestamp = LogStash::Timestamp.new(mail.date.to_time)
+      event.timestamp = LogStash::Timestamp.new(mail.date&.to_time)
 
       process_headers(mail, event) if @headers_target
 

--- a/spec/inputs/imap_spec.rb
+++ b/spec/inputs/imap_spec.rb
@@ -170,6 +170,18 @@ describe LogStash::Inputs::IMAP, :ecs_compatibility_support do
       end
     end
 
+    context "missing date" do
+      before do
+        mail.date = nil
+      end
+
+      it "should not cause an exception" do
+        event = input.parse_mail(mail)
+        expect( event.include?('Date') ).to be false
+        expect( event.timestamp ).not_to be nil
+      end
+    end
+
     context "headers_target => ''" do
       let(:config) { super().merge("headers_target" => '') }
 


### PR DESCRIPTION
This PR fixes the plugin crashes that happen when an email contains no date.

#18 also did the same, though with a slightly different mechanism. It was never merged, and is now out of date with `main`
