### PR TITLE
Upgrade email dependency to fix the Ruby net-smtp load regression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Upgrade `email` dependency so that supports Ruby 3.1. This also fixes the `net-smtp` load regression [#60](https://github.com/logstash-plugins/logstash-input-imap/pull/60)
+
 ## 3.2.0
   - Feat: ECS compatibility [#55](https://github.com/logstash-plugins/logstash-input-imap/pull/55)
     * added (optional) `headers_target` configuration option

--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-imap'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads mail from an IMAP server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths = ["lib"]
 
   # Files
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mail', '~> 2.6.3'
-  s.add_runtime_dependency 'mime-types', '2.6.2'
+  s.add_runtime_dependency 'mail', '~> 2.8'
+  s.add_runtime_dependency 'mime-types', '< 3'
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
### Description
`input-imap` plugin with  Logstash 8.10+ versions raises a `LoadError: no such file to load -- net/smtp` error.
It is due to ruby 3.1 regression that marks `net-smtp` as a bundled gem: https://github.com/ruby/ruby/pull/4530

### Solution
`input-imap` plugin uses `mail` gem and bundled `net-smtp` gem with ruby 3.1 support was added: https://github.com/mikel/mail/commit/d9d8dcc6bae1774a033ad488cea6217db3a3ebf3
So, we need to update `mail` dependency to `2.8.+` versions.

- Closes #59 