### PR TITLE
Remove Logstash version limiting.

### DIFF
--- a/logstash-input-imap.gemspec
+++ b/logstash-input-imap.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-core", ">= 8.10.0" # compatible with Ruby 3.1+
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'


### PR DESCRIPTION
### Description
Follow for #60 that we introduced a limitation to work with Logstash version. However, it is not required or should be limited since from `email` upgrade version, plugin isn't working as expected.